### PR TITLE
fix the self_attn module of DecoderLayer

### DIFF
--- a/lib/model_zoo/seecoder.py
+++ b/lib/model_zoo/seecoder.py
@@ -67,7 +67,7 @@ class DecoderLayer(nn.Module):
 
         super().__init__()
 
-        self.self_attn = nn.MultiheadAttention(dim, n_heads, dropout=dropout)
+        self.self_attn = nn.MultiheadAttention(dim, n_heads, dropout=dropout, batch_first=True)
         self.dropout1 = nn.Dropout(dropout)
         self.norm1 = nn.LayerNorm(dim)
 


### PR DESCRIPTION
Your paper specifies that the Decoder section performs a stacked multi-head self-attention operation, however I have found in the code that the behavior of the DecoderLayer class is inconsistent with the above description. By printing the attn_output_weights of the self_attn module, I found attention map shaped '([L, 1, 1])', and there is clearly a problem with such an attention computation. I provided a quickfix in this PR.